### PR TITLE
add sensor states

### DIFF
--- a/custom_components/evnex/sensor.py
+++ b/custom_components/evnex/sensor.py
@@ -148,7 +148,7 @@ class EvnexChargerNetworkStatusSensor(EvnexChargerEntity, SensorEntity):
     @property
     def native_value(self):
         if self.charge_point_brief:
-            return self.charge_point_brief.networkStatus
+            return str.lower(self.charge_point_brief.networkStatus)
         return None
 
 
@@ -400,7 +400,7 @@ class EvnexChargePortConnectorStatusSensor(
             (self.charger_id, self.connector_id)
         )
         if self.connector_brief:
-            return self.connector_brief.ocppStatus
+            return str.lower(self.connector_brief.ocppStatus)
         return None
 
     @property

--- a/custom_components/evnex/strings.json
+++ b/custom_components/evnex/strings.json
@@ -58,8 +58,8 @@
       "charger_network_status": {
         "name": "Charger network status",
         "state": {
-          "ONLINE": "Online",
-          "OFFLINE": "Offline"
+          "online": "Online",
+          "offline": "Offline"
         }
       },
       "session_energy": {
@@ -80,16 +80,16 @@
       "connector_status": {
         "name": "Connector status",
           "state": {
-            "OFFLINE": "Offline",
-            "AVAILABLE": "Available",
-            "PREPARING": "Preparing to charge",
-            "CHARGING": "Charging",
-            "SUSPENDED_EVSE": "Charging has been paused by the charge point",
-            "SUSPENDED_EV": "The vehicle is not currently requesting energy",
-            "FINISHING": "Finished charging - unplug charge point",
-            "RESERVED": "Reserved",
-            "UNAVAILABLE": "Disabled",
-            "FAULTED": "Faulted"
+            "offline": "Offline",
+            "available": "Available",
+            "preparing": "Preparing to charge",
+            "charging": "Charging",
+            "suspended_evse": "Charging has been paused by the charge point",
+            "suspended_ev": "The vehicle is not currently requesting energy",
+            "finishing": "Finished charging - unplug charge point",
+            "reserved": "Reserved",
+            "unavailable": "Disabled",
+            "faulted": "Faulted"
           }
       },
       "connector_current_l1": {

--- a/custom_components/evnex/strings.json
+++ b/custom_components/evnex/strings.json
@@ -56,7 +56,11 @@
         "name": "Organisation tier"
       },
       "charger_network_status": {
-        "name": "Charger network status"
+        "name": "Charger network status",
+        "state": {
+          "ONLINE": "Online",
+          "OFFLINE": "Offline"
+        }
       },
       "session_energy": {
         "name": "Session energy added"
@@ -74,7 +78,19 @@
         "name": "Session history"
       },
       "connector_status": {
-        "name": "Connector status"
+        "name": "Connector status",
+          "state": {
+            "OFFLINE": "Offline",
+            "AVAILABLE": "Available",
+            "PREPARING": "Preparing to charge",
+            "CHARGING": "Charging",
+            "SUSPENDED_EVSE": "Charging has been paused by the charge point",
+            "SUSPENDED_EV": "The vehicle is not currently requesting energy",
+            "FINISHING": "Finished charging - unplug charge point",
+            "RESERVED": "Reserved",
+            "UNAVAILABLE": "Disabled",
+            "FAULTED": "Faulted"
+          }
       },
       "connector_current_l1": {
         "name": "Current L1"

--- a/custom_components/evnex/translations/en.json
+++ b/custom_components/evnex/translations/en.json
@@ -32,8 +32,8 @@
             "charger_network_status": {
                 "name": "Charger network status",
                 "state": {
-                  "ONLINE": "Online",
-                  "OFFLINE": "Offline"
+                  "online": "Online",
+                  "offline": "Offline"
                 }
             },
             "charger_session_history": {
@@ -57,16 +57,16 @@
             "connector_status": {
                 "name": "Connector status",
                 "state": {
-                    "OFFLINE": "Offline",
-                    "AVAILABLE": "Available",
-                    "PREPARING": "Preparing to charge",
-                    "CHARGING": "Charging",
-                    "SUSPENDED_EVSE": "Charging has been paused by the charge point",
-                    "SUSPENDED_EV": "The vehicle is not currently requesting energy",
-                    "FINISHING": "Finished charging - unplug charge point",
-                    "RESERVED": "Reserved",
-                    "UNAVAILABLE": "Disabled",
-                    "FAULTED": "Faulted"
+                    "offline": "Offline",
+                    "available": "Available",
+                    "preparing": "Preparing to charge",
+                    "charging": "Charging",
+                    "suspended_evse": "Charging has been paused by the charge point",
+                    "suspended_ev": "The vehicle is not currently requesting energy",
+                    "finishing": "Finished charging - unplug charge point",
+                    "reserved": "Reserved",
+                    "unavailable": "Disabled",
+                    "faulted": "Faulted"
                 }
             },
             "connector_voltage_l1": {

--- a/custom_components/evnex/translations/en.json
+++ b/custom_components/evnex/translations/en.json
@@ -30,7 +30,11 @@
         },
         "sensor": {
             "charger_network_status": {
-                "name": "Charger network status"
+                "name": "Charger network status",
+                "state": {
+                  "ONLINE": "Online",
+                  "OFFLINE": "Offline"
+                }
             },
             "charger_session_history": {
                 "name": "Session history"
@@ -51,7 +55,19 @@
                 "name": "Metered power"
             },
             "connector_status": {
-                "name": "Connector status"
+                "name": "Connector status",
+                "state": {
+                    "OFFLINE": "Offline",
+                    "AVAILABLE": "Available",
+                    "PREPARING": "Preparing to charge",
+                    "CHARGING": "Charging",
+                    "SUSPENDED_EVSE": "Charging has been paused by the charge point",
+                    "SUSPENDED_EV": "The vehicle is not currently requesting energy",
+                    "FINISHING": "Finished charging - unplug charge point",
+                    "RESERVED": "Reserved",
+                    "UNAVAILABLE": "Disabled",
+                    "FAULTED": "Faulted"
+                }
             },
             "connector_voltage_l1": {
                 "name": "Voltage L1"


### PR DESCRIPTION
Adds translations for sensor states for network and charger status
Contains a small breaking change that the values are now lowercase, so may break some automations.
Technically speaking I could leave it uppercase and also set en.json to uppercase as well, this does work but of course the strings.json validation fails on this.