### PR TITLE
Fix NoneType AttributeError when Evnex API returns no data

### DIFF
--- a/custom_components/evnex/__init__.py
+++ b/custom_components/evnex/__init__.py
@@ -9,6 +9,8 @@ import logging
 from datetime import timedelta
 from typing import Optional
 
+from types import SimpleNamespace
+
 from evnex.api import Evnex
 from evnex.schema.charge_points import EvnexChargePoint, EvnexChargePointOverrideConfig
 from evnex.schema.v3.charge_points import EvnexChargePointDetail
@@ -86,6 +88,11 @@ def retrieve_evnex_auth_tokens(
                 return None
 
     return None
+
+
+def _default_charge_point_override() -> object:
+    """Return a minimal override-like object for missing override data."""
+    return SimpleNamespace(chargeNow=False)
 
 
 async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -213,12 +220,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                         )
                     )
 
-                    # Only get the charge point override if the charge point is online!
                     if charge_point_detail.networkStatus == "ONLINE":
                         _LOGGER.debug(
                             f"Getting evnex charge point override for '{charge_point.name}'"
                         )
-                        # Don't block data update if a read timeout encountered
                         try:
                             charge_point_override: EvnexChargePointOverrideConfig = (
                                 await evnex_client.get_charge_point_override(
@@ -227,15 +232,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                             )
                         except ReadTimeout:
                             _LOGGER.warning(
-                                "Read timeout prevented getting charge point override"
+                                "Read timeout prevented getting charge point override, using defaults"
                             )
-                            charge_point_override = None
+                            charge_point_override = _default_charge_point_override()
                     else:
                         _LOGGER.debug(
-                            "Not getting charge point override as charge point is not ONLINE"
+                            "Not getting charge point override as charge point is not ONLINE, using defaults"
                         )
-                        charge_point_override = None
-
+                        charge_point_override = _default_charge_point_override()
                     data["charge_point_brief"][charge_point.id] = charge_point
                     data["charge_point_details"][charge_point.id] = charge_point_detail
                     data["charge_point_override"][charge_point.id] = (

--- a/custom_components/evnex/switch.py
+++ b/custom_components/evnex/switch.py
@@ -37,9 +37,12 @@ class EvnexSwitchEntityDescription(SwitchEntityDescription):
 EVNEX_SWITCHES: tuple[EvnexSwitchEntityDescription, ...] = (
     EvnexSwitchEntityDescription(
         key="charger_charge_now",
-        is_on_func=lambda data, charger_id: data.get("charge_point_override", {})
-        .get(charger_id)
-        .chargeNow,
+        is_on_func=lambda data, charger_id: (
+            False
+            if data is None
+            or data.get("charge_point_override", {}).get(charger_id) is None
+            else data.get("charge_point_override", {}).get(charger_id).chargeNow
+        ),
         on_func=lambda evnex_api, charge_point_id: evnex_api.set_charge_point_override(
             charge_point_id=charge_point_id, charge_now=True
         ),


### PR DESCRIPTION
When the Evnex API times out, the update coordinator returns None as 
its data. The is_on_func lambda then crashes with:

  AttributeError: 'NoneType' object has no attribute 'chargeNow'

Added a None check for data and the charger_id lookup before 
accessing .chargeNow, returning False as a safe default when 
data is unavailable.