### PR TITLE
Fix recurring "Failed to load existing session data" by truncating token file on write

### DIFF
--- a/custom_components/evnex/__init__.py
+++ b/custom_components/evnex/__init__.py
@@ -67,7 +67,7 @@ def persist_evnex_auth_tokens(
         "access_token": access_token,
     }
 
-    with open(os.open(file, os.O_CREAT | os.O_WRONLY, 0o600), "w") as spf:
+    with open(os.open(file, os.O_CREAT | os.O_WRONLY | os.O_TRUNC, 0o600), "w") as spf:
         json.dump(session_dict, spf)
 
 


### PR DESCRIPTION
## Problem

The integration logs this error on (almost) every token refresh:

```
ERROR (SyncWorker_x) [custom_components.evnex] Failed to load existing session data, overwriting!
```

## Root cause

`persist_evnex_auth_tokens()` writes the session token file (`evnex_session.json`) with:

```python
with open(os.open(file, os.O_CREAT | os.O_WRONLY, 0o600), "w") as spf:
    json.dump(session_dict, spf)
```

There is no `os.O_TRUNC`, so the write overwrites from offset 0 but does **not** truncate the file. When the newly serialized JSON is shorter than the file's previous contents (which happens as tokens vary in length on refresh), the trailing bytes of the old content survive. The file then contains a valid JSON object followed by orphaned bytes, e.g.:

```
...AsCwq1Blzf-9EPaznOst0cYPG1pyWkIaNg"}}fsx-49NdhJPg"}}
```

On the next refresh, `json.load()` raises `JSONDecodeError`, which triggers the "Failed to load existing session data, overwriting!" error and the file is rewritten — again without truncation — so the corruption recurs indefinitely. It also means persisted tokens can be unusable across restarts.

## Fix

Add `os.O_TRUNC` to the open flags so the file is truncated on each write and always contains exactly the current JSON. Verified on a live install: the token file went from a corrupt 15 KB to a clean ~3.7 KB valid JSON and the error stopped recurring.