### PR TITLE
CI: scope prerelease flag to the matrix leg that needs it

### DIFF
--- a/.github/workflows/combined.yaml
+++ b/.github/workflows/combined.yaml
@@ -41,12 +41,17 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Minimum supported version (keep in sync with hacs.json)
+          # Minimum supported version (keep in sync with hacs.json).
+          # HA 2025.1 pins a pre-release transitively (aiohasupervisor beta),
+          # which is safe to allow here: ~= can only resolve 2025.1.x stables.
           - name: "2025.1"
             ha-constraint: "homeassistant~=2025.1.0"
-          # Newest HA supported by pytest-homeassistant-custom-component
+            prerelease-flag: "--prerelease=allow"
+          # Newest HA supported by pytest-homeassistant-custom-component.
+          # No prerelease flag, so beta-week HA releases can never be picked.
           - name: "latest"
             ha-constraint: "homeassistant"
+            prerelease-flag: ""
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
@@ -55,7 +60,6 @@ jobs:
       - name: Install with matrix Home Assistant version
         run: |
           uv venv
-          # HA pins pre-release dependencies (e.g. aiohasupervisor betas)
-          uv pip install --prerelease=allow -e . --group dev "${{ matrix.ha-constraint }}"
+          uv pip install ${{ matrix.prerelease-flag }} -e . --group dev "${{ matrix.ha-constraint }}"
       - name: Run tests
         run: uv run --no-sync pytest tests/


### PR DESCRIPTION
Addresses the Codex post-merge finding on #90: `--prerelease=allow` applied globally meant the unconstrained **latest** leg could resolve Home Assistant itself to a `b*` release during HA beta weeks, failing CI on an unsupported core.

The flag is now a per-leg matrix variable:
- **2025.1 floor**: keeps `--prerelease=allow` — required for HA 2025.1's transitive `aiohasupervisor==0.2.2b5` pin, and safe because `~=2025.1.0` expands to `==2025.1.*`, which no future beta can satisfy
- **latest**: no flag at all, so a prerelease HA can never be selected

(`--prerelease=if-necessary`/`if-necessary-or-explicit` were tried first but don't cover transitive exact prerelease pins.)

Verified locally with the exact CI commands: floor resolves HA 2025.1.4, latest resolves HA 2026.2.3, 7/7 tests pass on both.