### PR TITLE
Adopt the evnex 0.7 auth lifecycle and modernise to runtime_data (0.9.0b1)

### DIFF
--- a/.docker/services/run
+++ b/.docker/services/run
@@ -6,7 +6,7 @@ bashio::log.green "Installing evnex library for Home Assistant Core..."
 
 cd /config || bashio::exit.nok "Can't find config folder!"
 
-pip3 install --upgrade evnex || bashio::log.info "Failed to install python evnex library"
+pip3 install --upgrade --pre evnex || bashio::log.info "Failed to install python evnex library"
 
 # Enable Jemalloc for Home Assistant Core, unless disabled
 if [[ -z "${DISABLE_JEMALLOC+x}" ]]; then

--- a/.github/workflows/combined.yaml
+++ b/.github/workflows/combined.yaml
@@ -8,14 +8,14 @@ jobs:
     name: Code Analysis
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Check formatting
         uses: chartboost/ruff-action@v1
 
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         name: Download repo
         with:
           fetch-depth: 0
@@ -23,12 +23,6 @@ jobs:
         name: Setup Python
         with:
           python-version: "3.11"
-      - uses: actions/cache@v4
-        name: Cache
-        with:
-          path: |
-            ~/.cache/pip
-          key: custom-component-ci
       - uses: "home-assistant/actions/hassfest@master"
       - uses: hacs/action@main
         with:

--- a/custom_components/evnex/__init__.py
+++ b/custom_components/evnex/__init__.py
@@ -188,7 +188,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EvnexConfigEntry) -> boo
         ISSUE_URL,
     )
 
-    tokens = TokenSet.from_dict(entry.data["tokens"])
+    tokens = TokenSet.from_dict(entry.data.get("tokens") or {})
 
     async def on_token_update(tokens: TokenSet) -> None:
         """Persist rotated tokens to the config entry."""

--- a/custom_components/evnex/__init__.py
+++ b/custom_components/evnex/__init__.py
@@ -6,48 +6,31 @@ Custom integration to integrate Evnex with Home Assistant.
 import json
 import logging
 import os
-from datetime import timedelta
 
 from evnex.api import Evnex
-from evnex.schema.charge_points import EvnexChargePoint, EvnexChargePointOverrideConfig
-from evnex.schema.v3.charge_points import EvnexChargePointDetail
+from evnex.auth import EvnexAuth, TokenSet
 
-from evnex.schema.user import EvnexUserDetail
-from evnex.errors import NotAuthorizedException
-from pycognito.exceptions import MFAChallengeException
-
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.const import CONF_USERNAME, CONF_PASSWORD, Platform
+from homeassistant.const import CONF_PASSWORD, Platform
 from homeassistant.helpers import entity_registry as er
-from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers.httpx_client import get_async_client
-from homeassistant.helpers.update_coordinator import (
-    DataUpdateCoordinator,
-    UpdateFailed,
-)
-from httpx import HTTPStatusError, ReadTimeout
 
 from .const import (
     CONF_ACCESS_TOKEN,
     CONF_ID_TOKEN,
     CONF_REFRESH_TOKEN,
-    DATA_CLIENT,
-    DATA_COORDINATOR,
     DOMAIN,
     ISSUE_URL,
     PLATFORMS,
     TOKEN_FILE_NAME,
     VERSION,
 )
-from .models import EvnexCoordinatorData
-
-SCAN_INTERVAL = timedelta(minutes=5)
+from .coordinator import EvnexCoordinator, EvnexConfigEntry, EvnexRuntimeData
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
 
-def _read_tokens_from_file(hass: HomeAssistant, entry: ConfigEntry) -> dict | None:
+def _read_tokens_from_file(hass: HomeAssistant, entry: EvnexConfigEntry) -> dict | None:
     """Read auth tokens from the legacy file-based storage. Used only for migration."""
     config_dir = hass.config.config_dir
     file = os.path.join(config_dir, TOKEN_FILE_NAME)
@@ -73,20 +56,9 @@ def _remove_legacy_token_file(hass: HomeAssistant) -> None:
         os.unlink(file)
 
 
-def _async_persist_tokens(
-    hass: HomeAssistant, entry: ConfigEntry, evnex_client: Evnex
-) -> None:
-    """Store the client's current tokens in the config entry if they changed."""
-    tokens = {
-        CONF_ID_TOKEN: evnex_client.id_token,
-        CONF_REFRESH_TOKEN: evnex_client.refresh_token,
-        CONF_ACCESS_TOKEN: evnex_client.access_token,
-    }
-    if any(entry.data.get(key) != value for key, value in tokens.items()):
-        hass.config_entries.async_update_entry(entry, data={**entry.data, **tokens})
-
-
-async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+async def async_migrate_entry(
+    hass: HomeAssistant, config_entry: EvnexConfigEntry
+) -> bool:
     """Migrate old config entry to a newer version."""
     _LOGGER.debug(
         "Migrating Evnex config entry from version %s.%s",
@@ -174,6 +146,20 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
                 new_data.setdefault(CONF_ACCESS_TOKEN, None)
             new_minor_version = 3
 
+        if new_minor_version == 3:
+            # 1.3 -> 1.4: fold the flat token fields into a single TokenSet,
+            # and stop storing the account password now that the library
+            # persists rotated tokens via a callback instead of re-authenticating.
+            _LOGGER.info("Migrating Evnex config entry to the new token storage format")
+            token_set = TokenSet(
+                id_token=new_data.pop(CONF_ID_TOKEN, None),
+                refresh_token=new_data.pop(CONF_REFRESH_TOKEN, None),
+                access_token=new_data.pop(CONF_ACCESS_TOKEN, None),
+            )
+            new_data["tokens"] = token_set.to_dict()
+            new_data.pop(CONF_PASSWORD, None)
+            new_minor_version = 4
+
         hass.config_entries.async_update_entry(
             config_entry, data=new_data, minor_version=new_minor_version
         )
@@ -194,12 +180,7 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
     return True
 
 
-async def async_setup(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    """Disallow configuration via YAML"""
-    return True
-
-
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_setup_entry(hass: HomeAssistant, entry: EvnexConfigEntry) -> bool:
     """Load the saved entities."""
     _LOGGER.info(
         "Version %s is starting, if you have any issues please report them here: %s",
@@ -207,188 +188,32 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         ISSUE_URL,
     )
 
-    username = entry.data[CONF_USERNAME]
-    password = entry.data[CONF_PASSWORD]
+    tokens = TokenSet.from_dict(entry.data["tokens"])
 
-    # Load tokens from config entry data (migrated from file in async_migrate_entry)
-    httpx_client = get_async_client(hass)
-
-    try:
-        evnex_client: Evnex = await hass.async_add_executor_job(
-            Evnex,
-            username,
-            password,
-            entry.data.get(CONF_ID_TOKEN),
-            entry.data.get(CONF_REFRESH_TOKEN),
-            entry.data.get(CONF_ACCESS_TOKEN),
-            None,
-            httpx_client,
+    async def on_token_update(tokens: TokenSet) -> None:
+        """Persist rotated tokens to the config entry."""
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, "tokens": tokens.to_dict()}
         )
 
-    except NotAuthorizedException as exc:
-        _LOGGER.error("Not authorized while updating evnex info")
-        raise ConfigEntryAuthFailed from exc
-    except HTTPStatusError as exc:
-        _LOGGER.error("Failed to authenticate to evnex api")
-        raise ConfigEntryAuthFailed from exc
+    auth = EvnexAuth(tokens=tokens, on_token_update=on_token_update)
+    client = Evnex(auth=auth, httpx_client=get_async_client(hass))
 
-    hass.data.setdefault(DOMAIN, {})
-
-    async def async_update_data(is_retry: bool = False) -> EvnexCoordinatorData:
-        """Fetch data from EVNEX API"""
-
-        data = EvnexCoordinatorData()
-
-        try:
-            _LOGGER.info("Getting evnex user detail")
-            account: EvnexUserDetail = await evnex_client.get_user_detail()
-
-            _async_persist_tokens(hass, entry, evnex_client)
-
-            data.user = account
-
-            for org in account.organisations:
-                _LOGGER.info(
-                    f"Getting evnex charge points for '{org.name}' (Org ID: {org.id}, Slug: {org.slug})"
-                )
-                charge_points: list[EvnexChargePoint] = list()
-                try:
-                    charge_points = await evnex_client.get_org_charge_points(org.id)
-                except HTTPStatusError:
-                    _LOGGER.info("Org ID not supported switching to Slug")
-                    charge_points = await evnex_client.get_org_charge_points(org.slug)
-                data.charge_points_by_org[org.id] = [cp for cp in charge_points]
-                data.org_briefs[org.id] = org
-                _LOGGER.debug(f"Getting evnex org insights for {org.name}")
-                daily_insights = await evnex_client.get_org_insight(
-                    days=7, org_id=org.id
-                )
-                data.org_insights[org.id] = daily_insights
-
-                for charge_point in charge_points:
-                    # Map charge_point.id back to org.id
-                    data.charge_point_to_org_map[charge_point.id] = org.id
-
-                    _LOGGER.debug(
-                        f"Getting evnex charge point data for '{charge_point.name}'"
-                    )
-                    api_v3_response = await evnex_client.get_charge_point_detail_v3(
-                        charge_point_id=charge_point.id
-                    )
-                    charge_point_detail: EvnexChargePointDetail = (
-                        api_v3_response.data.attributes
-                    )
-
-                    for connector_brief in charge_point_detail.connectors:
-                        data.connector_brief[
-                            (charge_point.id, connector_brief.connectorId)
-                        ] = connector_brief
-
-                    _LOGGER.debug(
-                        f"Getting evnex charge point sessions for '{charge_point.name}'"
-                    )
-                    charge_point_sessions = (
-                        await evnex_client.get_charge_point_sessions(
-                            charge_point_id=charge_point.id
-                        )
-                    )
-
-                    # Only get the charge point override if the charge point is online!
-                    if charge_point_detail.networkStatus == "ONLINE":
-                        _LOGGER.debug(
-                            f"Getting evnex charge point override for '{charge_point.name}'"
-                        )
-                        # Don't block data update if a read timeout encountered
-                        try:
-                            charge_point_override: EvnexChargePointOverrideConfig = (
-                                await evnex_client.get_charge_point_override(
-                                    charge_point_id=charge_point.id
-                                )
-                            )
-                            data.charge_point_override[charge_point.id] = (
-                                charge_point_override
-                            )
-                        except ReadTimeout:
-                            _LOGGER.warning(
-                                "Read timeout prevented getting charge point override"
-                            )
-                    else:
-                        _LOGGER.debug(
-                            "Not getting charge point override as charge point is not ONLINE"
-                        )
-
-                    data.charge_point_brief[charge_point.id] = charge_point
-                    data.charge_point_details[charge_point.id] = charge_point_detail
-                    data.charge_point_sessions[charge_point.id] = charge_point_sessions
-
-            return data
-        except NotAuthorizedException as err:
-            if not is_retry:
-                _LOGGER.debug("Refreshing auth and trying again")
-                try:
-                    await hass.async_add_executor_job(evnex_client.authenticate)
-                except MFAChallengeException as mfa_err:
-                    # Password re-auth needs an MFA code, which only the user
-                    # can provide; trigger the reauth flow.
-                    raise ConfigEntryAuthFailed(
-                        "Session expired and account requires MFA to sign in again"
-                    ) from mfa_err
-                except NotAuthorizedException as auth_err:
-                    raise ConfigEntryAuthFailed(
-                        "Stored credentials were rejected"
-                    ) from auth_err
-                _async_persist_tokens(hass, entry, evnex_client)
-                return await async_update_data(is_retry=True)
-            _LOGGER.warning(
-                "EVNEX Session Token is invalid and failed attempt to re-login"
-            )
-            raise ConfigEntryAuthFailed(
-                "Re-authentication succeeded but the API still rejects requests"
-            ) from err
-        except MFAChallengeException as err:
-            # Raised when the client has no usable tokens and signing in with
-            # the stored password requires an MFA code only the user can provide
-            raise ConfigEntryAuthFailed(
-                "Account requires MFA to sign in again"
-            ) from err
-        except Exception as err:
-            _LOGGER.exception(
-                f"Unhandled exception while updating evnex info {err=} {type(err)}"
-            )
-            raise UpdateFailed from err
-
-    coordinator: DataUpdateCoordinator[EvnexCoordinatorData] = DataUpdateCoordinator(
-        hass,
-        _LOGGER,
-        name=DOMAIN,
-        update_method=async_update_data,
-        update_interval=SCAN_INTERVAL,
-        config_entry=entry,
-    )
-
-    hass.data[DOMAIN][entry.entry_id] = {
-        DATA_CLIENT: evnex_client,
-        DATA_COORDINATOR: coordinator,
-    }
+    coordinator = EvnexCoordinator(hass, client, entry)
 
     # Fetch initial data so we have data when entities subscribe
     #
     # If the refresh fails, async_config_entry_first_refresh will
     # raise ConfigEntryNotReady and setup will try again later
-
     await coordinator.async_config_entry_first_refresh()
 
+    entry.runtime_data = EvnexRuntimeData(client=client, coordinator=coordinator)
+
     # Setup components
-    # hass.config_entries.async_setup_platforms(entry, PLATFORMS)
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True
 
 
-async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_unload_entry(hass: HomeAssistant, entry: EvnexConfigEntry) -> bool:
     """Unload a config entry."""
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
-
-    return unload_ok
+    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/evnex/button.py
+++ b/custom_components/evnex/button.py
@@ -3,9 +3,9 @@ from dataclasses import dataclass
 from collections.abc import Awaitable, Callable
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .coordinator import EvnexConfigEntry
 from .entity import EvnexChargerEntity, EvnexCoordinator
 from evnex.api import Evnex
 
@@ -13,7 +13,7 @@ from evnex.schema.user import EvnexUserDetail
 
 from evnex.schema.charge_points import EvnexChargePoint
 
-from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN, CHARGER_SESSION_READY_STATES
+from .const import CHARGER_SESSION_READY_STATES
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -42,9 +42,9 @@ class EvnexButtonSensorEntityDescription(ButtonEntityDescription):
 EVNEX_BUTTONS: tuple[EvnexButtonSensorEntityDescription, ...] = (
     EvnexButtonSensorEntityDescription(
         key="charger_stop_session",
-        available=lambda coordinator,
-        charger_id,
-        connector_id: _is_charger_session_ready(coordinator, charger_id, connector_id),
+        available=lambda coordinator, charger_id, connector_id: (
+            _is_charger_session_ready(coordinator, charger_id, connector_id)
+        ),
         press_fn=lambda evnex_api, charge_point_id, org_id: evnex_api.stop_charge_point(
             charge_point_id=charge_point_id, org_id=org_id
         ),
@@ -54,15 +54,14 @@ EVNEX_BUTTONS: tuple[EvnexButtonSensorEntityDescription, ...] = (
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: EvnexConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Evnex button sensor entity."""
 
     entities: list = []
-    hass_data = hass.data[DOMAIN][config_entry.entry_id]
-    evnex_api_client = hass_data[DATA_CLIENT]
-    coordinator = hass_data[DATA_COORDINATOR]
+    evnex_api_client = config_entry.runtime_data.client
+    coordinator = config_entry.runtime_data.coordinator
     if not coordinator.data or not coordinator.data.user:
         _LOGGER.warning(
             "Button setup: Coordinator data or user data not available yet."

--- a/custom_components/evnex/config_flow.py
+++ b/custom_components/evnex/config_flow.py
@@ -73,6 +73,8 @@ class EvnexConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
         client = Evnex(auth=self._auth, httpx_client=get_async_client(self.hass))
         user = await client.get_user_detail()
 
+        await self.async_set_unique_id(str(user.id))
+
         data = {
             CONF_USERNAME: self._username,
             "user_id": str(user.id),
@@ -81,21 +83,24 @@ class EvnexConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
         }
 
         if self._reauth_entry is not None:
-            stored_user_id = self._reauth_entry.data.get("user_id")
-            if stored_user_id is not None and stored_user_id != str(user.id):
-                return self.async_abort(reason="wrong_account")
+            # Compare against the entry's unique_id (set to the user id at
+            # creation), not a stored data field: entries created before
+            # user_id was recorded and migrated up to the current version
+            # would otherwise skip this account-identity check entirely.
+            self._abort_if_unique_id_mismatch(reason="wrong_account")
             merged_data = {**self._reauth_entry.data, **data}
-            merged_data.pop(CONF_PASSWORD, None)
-            merged_data.pop("id_token", None)
-            merged_data.pop("refresh_token", None)
-            merged_data.pop("access_token", None)
+            for legacy_key in (
+                CONF_PASSWORD,
+                "id_token",
+                "refresh_token",
+                "access_token",
+            ):
+                merged_data.pop(legacy_key, None)
             return self.async_update_reload_and_abort(
                 self._reauth_entry, data=merged_data
             )
 
-        await self.async_set_unique_id(str(user.id))
         self._abort_if_unique_id_configured()
-
         return self.async_create_entry(title=user.name or user.email, data=data)
 
     async def async_step_user(
@@ -157,22 +162,23 @@ class EvnexConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
                     result = await self._auth.start_authentication(
                         self._username, self._password
                     )
+                    if isinstance(result, TokenSet):
+                        return await self._async_finalize()
+                    self._challenge = result
+                    errors["base"] = "mfa_expired"
                 except InvalidCredentialsError:
-                    errors["base"] = "invalid_credentials"
                     return self.async_show_form(
                         step_id="user",
                         data_schema=STEP_USER_DATA_SCHEMA,
-                        errors=errors,
+                        errors={"base": "invalid_credentials"},
                     )
                 except PasswordChangeRequiredError:
                     return self.async_abort(reason="password_change_required")
+                except AbortFlow:
+                    raise
                 except Exception:  # pylint: disable=broad-except
                     logger.exception("Unexpected exception restarting authentication")
                     return self._show_mfa_form({"base": "unknown"})
-                if isinstance(result, TokenSet):
-                    return await self._async_finalize()
-                self._challenge = result
-                errors["base"] = "mfa_expired"
             except PasswordChangeRequiredError:
                 return self.async_abort(reason="password_change_required")
             except AbortFlow:

--- a/custom_components/evnex/config_flow.py
+++ b/custom_components/evnex/config_flow.py
@@ -8,26 +8,21 @@ from typing import Any
 import voluptuous as vol
 
 from homeassistant import config_entries
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.data_entry_flow import AbortFlow, FlowResult
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.config_entries import ConfigEntry, ConfigFlowResult
+from homeassistant.data_entry_flow import AbortFlow
 from homeassistant.const import CONF_USERNAME, CONF_PASSWORD
 from homeassistant.helpers.httpx_client import get_async_client
 
 from evnex.api import Evnex
-from evnex.errors import NotAuthorizedException
-from pycognito.exceptions import (
-    SMSMFAChallengeException,
-    SoftwareTokenMFAChallengeException,
+from evnex.auth import AuthChallenge, EvnexAuth, TokenSet
+from evnex.errors import (
+    ChallengeExpiredError,
+    InvalidChallengeResponseError,
+    InvalidCredentialsError,
+    PasswordChangeRequiredError,
 )
 
-from .const import (
-    CONF_ACCESS_TOKEN,
-    CONF_ID_TOKEN,
-    CONF_MFA_CODE,
-    CONF_REFRESH_TOKEN,
-    DOMAIN,
-)
+from .const import CONF_MFA_CODE, DOMAIN
 
 logger = logging.getLogger(__name__)
 
@@ -49,88 +44,63 @@ class EvnexConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
     """Handle a config flow for Evnex EV Charger."""
 
     VERSION = 1
-    MINOR_VERSION = 3
+    MINOR_VERSION = 4
 
     def __init__(self) -> None:
-        self._client: Evnex | None = None
+        self._auth: EvnexAuth | None = None
+        self._challenge: AuthChallenge | None = None
         self._username: str | None = None
         self._password: str | None = None
-        self._mfa_mode: str | None = None
         self._reauth_entry: ConfigEntry | None = None
 
-    async def _async_start_auth(self) -> str | None:
-        """Authenticate with username/password.
-
-        Returns the MFA mode ("TOTP" or "SMS") when the account requires a
-        code to finish signing in, or None when fully authenticated.
-
-        :raises InvalidAuth
-        """
-
-        def _create_client() -> Evnex:
-            # boto3 client construction inside Evnex/Cognito can perform
-            # blocking I/O (credential lookup), so keep it off the event loop
-            return Evnex(
-                username=self._username,
-                password=self._password,
-                httpx_client=get_async_client(self.hass),
-            )
-
-        self._client = await self.hass.async_add_executor_job(_create_client)
-        try:
-            await self.hass.async_add_executor_job(self._client.authenticate)
-        except SoftwareTokenMFAChallengeException:
-            return "TOTP"
-        except SMSMFAChallengeException:
-            return "SMS"
-        except NotAuthorizedException as err:
-            raise InvalidAuth from err
-        return None
-
-    def _show_mfa_form(self, errors: dict[str, str] | None = None) -> FlowResult:
+    def _show_mfa_form(self, errors: dict[str, str] | None = None) -> ConfigFlowResult:
+        assert self._challenge is not None
+        mfa_source = (
+            self._challenge.parameters.get("FRIENDLY_DEVICE_NAME")
+            or "your authenticator app"
+        )
         return self.async_show_form(
             step_id="mfa",
             data_schema=STEP_MFA_DATA_SCHEMA,
             errors=errors,
-            description_placeholders={
-                "mfa_source": "your authenticator app"
-                if self._mfa_mode == "TOTP"
-                else "the SMS we sent you"
-            },
+            description_placeholders={"mfa_source": mfa_source},
         )
 
-    async def _async_create_or_update_entry(self) -> FlowResult:
+    async def _async_finalize(self) -> ConfigFlowResult:
         """Fetch account details and create (or update, on reauth) the entry."""
-        user_data = await self._client.get_user_detail()
+        assert self._auth is not None and self._auth.tokens is not None
+
+        client = Evnex(auth=self._auth, httpx_client=get_async_client(self.hass))
+        user = await client.get_user_detail()
 
         data = {
             CONF_USERNAME: self._username,
-            CONF_PASSWORD: self._password,
-            "user_id": str(user_data.id),
-            "default_org_id": self._client.org_id,
-            CONF_ID_TOKEN: self._client.id_token,
-            CONF_REFRESH_TOKEN: self._client.refresh_token,
-            CONF_ACCESS_TOKEN: self._client.access_token,
+            "user_id": str(user.id),
+            "default_org_id": client.org_id,
+            "tokens": self._auth.tokens.to_dict(),
         }
 
         if self._reauth_entry is not None:
             stored_user_id = self._reauth_entry.data.get("user_id")
-            if stored_user_id is not None and stored_user_id != str(user_data.id):
+            if stored_user_id is not None and stored_user_id != str(user.id):
                 return self.async_abort(reason="wrong_account")
+            merged_data = {**self._reauth_entry.data, **data}
+            merged_data.pop(CONF_PASSWORD, None)
+            merged_data.pop("id_token", None)
+            merged_data.pop("refresh_token", None)
+            merged_data.pop("access_token", None)
             return self.async_update_reload_and_abort(
-                self._reauth_entry, data={**self._reauth_entry.data, **data}
+                self._reauth_entry, data=merged_data
             )
 
-        await self.async_set_unique_id(str(user_data.id))
+        await self.async_set_unique_id(str(user.id))
         self._abort_if_unique_id_configured()
 
-        return self.async_create_entry(
-            title=user_data.name or user_data.email, data=data
-        )
+        return self.async_create_entry(title=user.name or user.email, data=data)
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Handle the initial step."""
         if user_input is None:
             return self.async_show_form(
@@ -140,16 +110,20 @@ class EvnexConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
         self._username = user_input[CONF_USERNAME].lower()
         self._password = user_input[CONF_PASSWORD]
 
-        errors = {}
+        errors: dict[str, str] = {}
         try:
-            if mfa_mode := await self._async_start_auth():
-                self._mfa_mode = mfa_mode
+            self._auth = EvnexAuth()
+            result = await self._auth.start_authentication(
+                self._username, self._password
+            )
+            if isinstance(result, AuthChallenge):
+                self._challenge = result
                 return self._show_mfa_form()
-            return await self._async_create_or_update_entry()
-        except CannotConnect:
-            errors["base"] = "cannot_connect"
-        except InvalidAuth:
+            return await self._async_finalize()
+        except InvalidCredentialsError:
             errors["base"] = "invalid_credentials"
+        except PasswordChangeRequiredError:
+            return self.async_abort(reason="password_change_required")
         except AbortFlow:
             raise
         except Exception:  # pylint: disable=broad-except
@@ -162,26 +136,45 @@ class EvnexConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
 
     async def async_step_mfa(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Verify a multifactor authentication code."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
+            assert self._auth is not None and self._challenge is not None
             try:
-                await self.hass.async_add_executor_job(
-                    self._client.respond_to_mfa_challenge,
-                    user_input[CONF_MFA_CODE].strip(),
-                    self._mfa_mode,
+                result = await self._auth.respond_to_challenge(
+                    self._challenge, user_input[CONF_MFA_CODE].strip()
                 )
-                return await self._async_create_or_update_entry()
-            except NotAuthorizedException:
-                # Wrong code, or the short-lived Cognito challenge session
-                # expired; restart the challenge so the next attempt can work.
+                if isinstance(result, TokenSet):
+                    return await self._async_finalize()
+                self._challenge = result
+                return self._show_mfa_form()
+            except InvalidChallengeResponseError:
                 errors["base"] = "invalid_mfa_code"
+            except ChallengeExpiredError:
                 try:
-                    await self._async_start_auth()
-                except InvalidAuth:
+                    result = await self._auth.start_authentication(
+                        self._username, self._password
+                    )
+                except InvalidCredentialsError:
                     errors["base"] = "invalid_credentials"
+                    return self.async_show_form(
+                        step_id="user",
+                        data_schema=STEP_USER_DATA_SCHEMA,
+                        errors=errors,
+                    )
+                except PasswordChangeRequiredError:
+                    return self.async_abort(reason="password_change_required")
+                except Exception:  # pylint: disable=broad-except
+                    logger.exception("Unexpected exception restarting authentication")
+                    return self._show_mfa_form({"base": "unknown"})
+                if isinstance(result, TokenSet):
+                    return await self._async_finalize()
+                self._challenge = result
+                errors["base"] = "mfa_expired"
+            except PasswordChangeRequiredError:
+                return self.async_abort(reason="password_change_required")
             except AbortFlow:
                 raise
             except Exception:  # pylint: disable=broad-except
@@ -190,31 +183,33 @@ class EvnexConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
 
         return self._show_mfa_form(errors)
 
-    async def async_step_reauth(self, entry_data: dict[str, Any]) -> FlowResult:
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
         """Handle reauthentication when stored tokens are no longer valid."""
-        self._reauth_entry = self.hass.config_entries.async_get_entry(
-            self.context["entry_id"]
-        )
+        self._reauth_entry = self._get_reauth_entry()
         self._username = entry_data[CONF_USERNAME]
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
-    ) -> FlowResult:
+    ) -> ConfigFlowResult:
         """Confirm the password (and MFA, if enabled) to re-establish a session."""
-        errors = {}
+        errors: dict[str, str] = {}
 
         if user_input is not None:
             self._password = user_input[CONF_PASSWORD]
             try:
-                if mfa_mode := await self._async_start_auth():
-                    self._mfa_mode = mfa_mode
+                self._auth = EvnexAuth()
+                result = await self._auth.start_authentication(
+                    self._username, self._password
+                )
+                if isinstance(result, AuthChallenge):
+                    self._challenge = result
                     return self._show_mfa_form()
-                return await self._async_create_or_update_entry()
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
-            except InvalidAuth:
+                return await self._async_finalize()
+            except InvalidCredentialsError:
                 errors["base"] = "invalid_credentials"
+            except PasswordChangeRequiredError:
+                return self.async_abort(reason="password_change_required")
             except AbortFlow:
                 raise
             except Exception:  # pylint: disable=broad-except
@@ -225,13 +220,5 @@ class EvnexConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ignore
             step_id="reauth_confirm",
             data_schema=vol.Schema({vol.Required(CONF_PASSWORD): str}),
             errors=errors,
-            description_placeholders={"username": self._username},
+            description_placeholders={"username": self._username or ""},
         )
-
-
-class CannotConnect(HomeAssistantError):
-    """Error to indicate we cannot connect."""
-
-
-class InvalidAuth(HomeAssistantError):
-    """Error to indicate there is invalid auth."""

--- a/custom_components/evnex/const.py
+++ b/custom_components/evnex/const.py
@@ -6,7 +6,7 @@ from homeassistant.const import Platform
 NAME = "evnex"
 DOMAIN = "evnex"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.8.0b1"
+VERSION = "0.9.0b1"
 ATTRIBUTION = "Data provided by https://evnex.io"
 ISSUE_URL = "https://github.com/hardbyte/ha-evnex/issues"
 
@@ -25,10 +25,6 @@ CONF_REFRESH_TOKEN = "refresh_token"
 CONF_ACCESS_TOKEN = "access_token"
 
 CONF_MFA_CODE = "mfa_code"
-
-# Internal
-DATA_CLIENT = "evnex-client"
-DATA_COORDINATOR = "coordinator"
 
 # Coordinator Data Keys
 

--- a/custom_components/evnex/coordinator.py
+++ b/custom_components/evnex/coordinator.py
@@ -1,0 +1,149 @@
+"""DataUpdateCoordinator for the Evnex integration."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import timedelta
+
+from evnex.api import Evnex
+from evnex.errors import EvnexAuthError
+from evnex.schema.charge_points import EvnexChargePoint, EvnexChargePointOverrideConfig
+from evnex.schema.user import EvnexUserDetail
+from evnex.schema.v3.charge_points import EvnexChargePointDetail
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import (
+    DataUpdateCoordinator,
+    UpdateFailed,
+)
+from httpx import HTTPStatusError, ReadTimeout
+
+from .const import DOMAIN
+from .models import EvnexCoordinatorData
+
+SCAN_INTERVAL = timedelta(minutes=5)
+
+_LOGGER: logging.Logger = logging.getLogger(__package__)
+
+
+class EvnexCoordinator(DataUpdateCoordinator[EvnexCoordinatorData]):
+    """Coordinates fetching Evnex data from a single API endpoint."""
+
+    def __init__(
+        self, hass: HomeAssistant, client: Evnex, entry: EvnexConfigEntry
+    ) -> None:
+        """Initialize the coordinator."""
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=SCAN_INTERVAL,
+            config_entry=entry,
+        )
+        self.client = client
+
+    async def _async_update_data(self) -> EvnexCoordinatorData:
+        """Fetch data from EVNEX API"""
+
+        data = EvnexCoordinatorData()
+
+        try:
+            _LOGGER.info("Getting evnex user detail")
+            account: EvnexUserDetail = await self.client.get_user_detail()
+
+            data.user = account
+
+            for org in account.organisations:
+                _LOGGER.info(
+                    f"Getting evnex charge points for '{org.name}' (Org ID: {org.id}, Slug: {org.slug})"
+                )
+                charge_points: list[EvnexChargePoint] = list()
+                try:
+                    charge_points = await self.client.get_org_charge_points(org.id)
+                except HTTPStatusError:
+                    _LOGGER.info("Org ID not supported switching to Slug")
+                    charge_points = await self.client.get_org_charge_points(org.slug)
+                data.charge_points_by_org[org.id] = [cp for cp in charge_points]
+                data.org_briefs[org.id] = org
+                _LOGGER.debug(f"Getting evnex org insights for {org.name}")
+                daily_insights = await self.client.get_org_insight(
+                    days=7, org_id=org.id
+                )
+                data.org_insights[org.id] = daily_insights
+
+                for charge_point in charge_points:
+                    # Map charge_point.id back to org.id
+                    data.charge_point_to_org_map[charge_point.id] = org.id
+
+                    _LOGGER.debug(
+                        f"Getting evnex charge point data for '{charge_point.name}'"
+                    )
+                    api_v3_response = await self.client.get_charge_point_detail_v3(
+                        charge_point_id=charge_point.id
+                    )
+                    charge_point_detail: EvnexChargePointDetail = (
+                        api_v3_response.data.attributes
+                    )
+
+                    for connector_brief in charge_point_detail.connectors:
+                        data.connector_brief[
+                            (charge_point.id, connector_brief.connectorId)
+                        ] = connector_brief
+
+                    _LOGGER.debug(
+                        f"Getting evnex charge point sessions for '{charge_point.name}'"
+                    )
+                    charge_point_sessions = await self.client.get_charge_point_sessions(
+                        charge_point_id=charge_point.id
+                    )
+
+                    # Only get the charge point override if the charge point is online!
+                    if charge_point_detail.networkStatus == "ONLINE":
+                        _LOGGER.debug(
+                            f"Getting evnex charge point override for '{charge_point.name}'"
+                        )
+                        # Don't block data update if a read timeout encountered
+                        try:
+                            charge_point_override: EvnexChargePointOverrideConfig = (
+                                await self.client.get_charge_point_override(
+                                    charge_point_id=charge_point.id
+                                )
+                            )
+                            data.charge_point_override[charge_point.id] = (
+                                charge_point_override
+                            )
+                        except ReadTimeout:
+                            _LOGGER.warning(
+                                "Read timeout prevented getting charge point override"
+                            )
+                    else:
+                        _LOGGER.debug(
+                            "Not getting charge point override as charge point is not ONLINE"
+                        )
+
+                    data.charge_point_brief[charge_point.id] = charge_point
+                    data.charge_point_details[charge_point.id] = charge_point_detail
+                    data.charge_point_sessions[charge_point.id] = charge_point_sessions
+
+            return data
+        except EvnexAuthError as err:
+            raise ConfigEntryAuthFailed("Evnex session is no longer valid") from err
+        except Exception as err:
+            _LOGGER.exception(
+                f"Unhandled exception while updating evnex info {err=} {type(err)}"
+            )
+            raise UpdateFailed from err
+
+
+@dataclass
+class EvnexRuntimeData:
+    """Data stored on the config entry at runtime."""
+
+    client: Evnex
+    coordinator: EvnexCoordinator
+
+
+type EvnexConfigEntry = ConfigEntry[EvnexRuntimeData]

--- a/custom_components/evnex/entity.py
+++ b/custom_components/evnex/entity.py
@@ -10,15 +10,10 @@ from evnex.schema.org import EvnexOrgBrief
 
 from evnex.models import parse_model
 from homeassistant.helpers.entity import DeviceInfo
-from homeassistant.helpers.update_coordinator import (
-    CoordinatorEntity,
-    DataUpdateCoordinator,
-)
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN, NAME
-from .models import EvnexCoordinatorData
-
-type EvnexCoordinator = DataUpdateCoordinator[EvnexCoordinatorData]
+from .coordinator import EvnexCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/evnex/manifest.json
+++ b/custom_components/evnex/manifest.json
@@ -13,7 +13,7 @@
     "evnex"
   ],
   "requirements": [
-    "evnex==0.6.1"
+    "evnex==0.7.0b1"
   ],
-  "version": "0.8.0b1"
+  "version": "0.9.0b1"
 }

--- a/custom_components/evnex/number.py
+++ b/custom_components/evnex/number.py
@@ -13,10 +13,10 @@ from homeassistant.components.number import (
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DATA_UPDATED, DATA_CLIENT, DATA_COORDINATOR, DOMAIN
+from .const import DATA_UPDATED
+from .coordinator import EvnexConfigEntry
 from .entity import EvnexChargePointConnectorEntity
 from evnex.api import Evnex
 from evnex.schema.charge_points import EvnexChargePointLoadSchedule
@@ -37,14 +37,14 @@ class EvnexNumberDescription(NumberEntityDescription):
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: EvnexConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the number sliders."""
 
     entities = []
-    evnex_api_client = hass.data[DOMAIN][config_entry.entry_id][DATA_CLIENT]
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
+    evnex_api_client = config_entry.runtime_data.client
+    coordinator = config_entry.runtime_data.coordinator
     if not coordinator.data or not coordinator.data.user:
         _LOGGER.warning(
             "Number setup: Coordinator data or user data not available yet."

--- a/custom_components/evnex/sensor.py
+++ b/custom_components/evnex/sensor.py
@@ -13,7 +13,6 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     UnitOfElectricPotential,
     UnitOfEnergy,
@@ -24,13 +23,13 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from .coordinator import EvnexConfigEntry
 from .entity import (
     EvnexChargePointConnectorEntity,
     EvnexCoordinator,
     EvnexOrgEntity,
     EvnexChargerEntity,
 )
-from .const import DATA_COORDINATOR, DOMAIN
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -668,13 +667,12 @@ class EvnexChargePortConnectorTemperatureSensor(
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: EvnexConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the sensor platform."""
 
-    # client = hass.data[DOMAIN][config_entry.entry_id][DATA_CLIENT]
-    coordinator = hass.data[DOMAIN][config_entry.entry_id][DATA_COORDINATOR]
+    coordinator = config_entry.runtime_data.coordinator
 
     entities: list[SensorEntity] = []
     if not coordinator.data:

--- a/custom_components/evnex/strings.json
+++ b/custom_components/evnex/strings.json
@@ -27,13 +27,14 @@
     "error": {
       "invalid_credentials": "Invalid credentials",
       "invalid_mfa_code": "The code was not accepted. A new code may have been requested; please try again.",
-      "cannot_connect": "Failed to connect",
+      "mfa_expired": "That code expired. We've requested a new challenge - please enter a fresh code.",
       "unknown": "Unexpected error"
     },
     "abort": {
       "already_configured": "Account is already configured",
       "reauth_successful": "Re-authentication was successful",
-      "wrong_account": "The credentials belong to a different Evnex account than this entry"
+      "wrong_account": "The credentials belong to a different Evnex account than this entry",
+      "password_change_required": "Your Evnex account requires a password change before it can sign in. Update it in the Evnex app, then try again."
     }
   },
   "options": {

--- a/custom_components/evnex/switch.py
+++ b/custom_components/evnex/switch.py
@@ -2,12 +2,11 @@ import logging
 from typing import Any, Callable, Awaitable
 from dataclasses import dataclass
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
-from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 
-from .const import DATA_CLIENT, DATA_COORDINATOR, DOMAIN
+from .coordinator import EvnexConfigEntry
 from .entity import (
     EvnexChargePointConnectorEntity,
     EvnexChargerEntity,
@@ -161,14 +160,13 @@ class EvnexChargerAvailabilitySwitch(EvnexChargePointConnectorEntity, SwitchEnti
 
 async def async_setup_entry(
     hass: HomeAssistant,
-    config_entry: ConfigEntry,
+    config_entry: EvnexConfigEntry,
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the switches."""
     entities = []
-    hass_data = hass.data[DOMAIN][config_entry.entry_id]
-    evnex_api_client = hass_data[DATA_CLIENT]
-    coordinator = hass_data[DATA_COORDINATOR]
+    evnex_api_client = config_entry.runtime_data.client
+    coordinator = config_entry.runtime_data.coordinator
     if not coordinator.data or not coordinator.data.user:
         _LOGGER.warning(
             "Switch setup: Coordinator data or user data not available yet."

--- a/custom_components/evnex/translations/en.json
+++ b/custom_components/evnex/translations/en.json
@@ -2,13 +2,14 @@
     "config": {
         "abort": {
             "already_configured": "Account is already configured",
+            "password_change_required": "Your Evnex account requires a password change before it can sign in. Update it in the Evnex app, then try again.",
             "reauth_successful": "Re-authentication was successful",
             "wrong_account": "The credentials belong to a different Evnex account than this entry"
         },
         "error": {
-            "cannot_connect": "Failed to connect",
             "invalid_credentials": "Invalid credentials",
             "invalid_mfa_code": "The code was not accepted. A new code may have been requested; please try again.",
+            "mfa_expired": "That code expired. We've requested a new challenge - please enter a fresh code.",
             "unknown": "Unexpected error"
         },
         "step": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 requires-python = ">=3.13"
 dependencies = [
     "homeassistant >= 2025.1.0",
-    "evnex >= 0.6.1",
+    "evnex >= 0.7.0b1",
 ]
 
 [dependency-groups]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from pycognito.exceptions import SoftwareTokenMFAChallengeException
+from evnex.auth import AuthChallenge, TokenSet
 
 pytest_plugins = "pytest_homeassistant_custom_component"
 
@@ -24,32 +24,60 @@ def make_user_detail(name="Test User"):
     return user
 
 
+def make_token_set(access_token="access-0"):
+    return TokenSet(
+        access_token=access_token, id_token="id-0", refresh_token="refresh-0"
+    )
+
+
+@pytest.fixture
+def mock_auth():
+    """A mocked EvnexAuth that authenticates without a challenge."""
+    auth = MagicMock()
+    auth.start_authentication = AsyncMock(return_value=make_token_set())
+    auth.respond_to_challenge = AsyncMock(return_value=make_token_set())
+    auth.tokens = make_token_set()
+    return auth
+
+
 @pytest.fixture
 def mock_evnex_client():
-    """A mocked Evnex client that authenticates without MFA."""
+    """A mocked Evnex client returned once auth succeeds."""
     client = MagicMock()
-    client.authenticate = MagicMock()
-    client.respond_to_mfa_challenge = MagicMock()
     client.get_user_detail = AsyncMock(return_value=make_user_detail())
     client.org_id = "org-1"
-    client.id_token = "id-0"
-    client.access_token = "access-0"
-    client.refresh_token = "refresh-0"
     return client
 
 
 @pytest.fixture
-def mock_evnex(mock_evnex_client):
-    """Patch the Evnex class used by the config flow."""
-    with patch(
-        "custom_components.evnex.config_flow.Evnex",
-        return_value=mock_evnex_client,
+def mock_evnex(mock_auth, mock_evnex_client):
+    """Patch EvnexAuth and Evnex as used by the config flow.
+
+    The returned mock is the Evnex client, with the EvnexAuth mock attached
+    as `.auth` for tests that need to drive authentication behaviour (e.g.
+    setting `side_effect` on `start_authentication`/`respond_to_challenge`).
+    """
+    mock_evnex_client.auth = mock_auth
+    with (
+        patch(
+            "custom_components.evnex.config_flow.EvnexAuth",
+            return_value=mock_auth,
+        ),
+        patch(
+            "custom_components.evnex.config_flow.Evnex",
+            return_value=mock_evnex_client,
+        ),
     ):
         yield mock_evnex_client
 
 
-def mfa_challenge():
-    return SoftwareTokenMFAChallengeException(
-        "Do Software Token MFA",
-        {"ChallengeName": "SOFTWARE_TOKEN_MFA", "Session": "opaque-session"},
+def mfa_challenge(friendly_device_name: str | None = "your authenticator app"):
+    parameters = {}
+    if friendly_device_name is not None:
+        parameters["FRIENDLY_DEVICE_NAME"] = friendly_device_name
+    return AuthChallenge(
+        name="SOFTWARE_TOKEN_MFA",
+        session="opaque-session",
+        username="user@example.com",
+        parameters=parameters,
     )

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -230,6 +230,36 @@ async def test_reauth_flow_with_mfa(hass: HomeAssistant, mock_evnex) -> None:
     assert "access_token" not in entry.data
 
 
+async def test_reauth_legacy_entry_without_user_id_blocks_wrong_account(
+    hass: HomeAssistant, mock_evnex
+) -> None:
+    """A legacy entry lacking user_id still blocks a different account.
+
+    The account-identity check must key off the entry's unique_id (set at
+    creation) rather than a stored user_id field that pre-user_id entries
+    migrated up to the current version may not have.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="different-user",
+        minor_version=4,
+        # No user_id in data, as for an entry created before it was recorded.
+        data={"username": CREDS["username"], "tokens": make_token_set().to_dict()},
+    )
+    entry.add_to_hass(hass)
+
+    entry.async_start_reauth(hass)
+    await hass.async_block_till_done()
+
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    result = await hass.config_entries.flow.async_configure(
+        flows[0]["flow_id"], {"password": "hunter2"}
+    )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "wrong_account"
+
+
 async def test_reauth_wrong_account_aborts(hass: HomeAssistant, mock_evnex) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,5 +1,11 @@
 """Tests for the evnex config flow, including MFA and reauthentication."""
 
+from evnex.errors import (
+    ChallengeExpiredError,
+    InvalidChallengeResponseError,
+    InvalidCredentialsError,
+    PasswordChangeRequiredError,
+)
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
@@ -7,7 +13,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.evnex.const import DOMAIN
 
-from .conftest import USER_ID, mfa_challenge
+from .conftest import USER_ID, make_token_set, mfa_challenge
 
 CREDS = {"username": "user@example.com", "password": "hunter2"}
 
@@ -27,20 +33,26 @@ async def test_user_flow_without_mfa(hass: HomeAssistant, mock_evnex) -> None:
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "Test User"
-    assert result["data"]["access_token"] == "access-0"
-    assert result["data"]["refresh_token"] == "refresh-0"
+    assert result["data"]["tokens"] == make_token_set().to_dict()
     assert result["data"]["user_id"] == USER_ID
-    mock_evnex.authenticate.assert_called_once()
+    assert "password" not in result["data"]
+    mock_evnex.auth.start_authentication.assert_called_once_with(
+        CREDS["username"], CREDS["password"]
+    )
 
 
 async def test_user_flow_with_mfa(hass: HomeAssistant, mock_evnex) -> None:
-    mock_evnex.authenticate.side_effect = mfa_challenge()
+    challenge = mfa_challenge()
+    mock_evnex.auth.start_authentication.return_value = challenge
 
     result = await start_user_flow(hass)
     result = await hass.config_entries.flow.async_configure(result["flow_id"], CREDS)
 
     assert result["type"] == FlowResultType.FORM
     assert result["step_id"] == "mfa"
+    assert result["description_placeholders"] == {
+        "mfa_source": "your authenticator app"
+    }
 
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"], {"mfa_code": "123456"}
@@ -48,18 +60,17 @@ async def test_user_flow_with_mfa(hass: HomeAssistant, mock_evnex) -> None:
 
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert result["title"] == "Test User"
-    mock_evnex.respond_to_mfa_challenge.assert_called_once_with("123456", "TOTP")
+    mock_evnex.auth.respond_to_challenge.assert_called_once_with(challenge, "123456")
 
 
 async def test_mfa_wrong_code_shows_error_and_recovers(
     hass: HomeAssistant, mock_evnex
 ) -> None:
-    from evnex.errors import NotAuthorizedException
-
-    mock_evnex.authenticate.side_effect = mfa_challenge()
-    mock_evnex.respond_to_mfa_challenge.side_effect = [
-        NotAuthorizedException("Wrong code"),
-        None,
+    challenge = mfa_challenge()
+    mock_evnex.auth.start_authentication.return_value = challenge
+    mock_evnex.auth.respond_to_challenge.side_effect = [
+        InvalidChallengeResponseError("Wrong code"),
+        make_token_set(),
     ]
 
     result = await start_user_flow(hass)
@@ -76,12 +87,74 @@ async def test_mfa_wrong_code_shows_error_and_recovers(
         result["flow_id"], {"mfa_code": "123456"}
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY
+    # Both attempts answered the same challenge.
+    for call in mock_evnex.auth.respond_to_challenge.call_args_list:
+        assert call.args[0] is challenge
+
+
+async def test_mfa_expired_then_restarts(hass: HomeAssistant, mock_evnex) -> None:
+    first_challenge = mfa_challenge()
+    second_challenge = mfa_challenge()
+    mock_evnex.auth.start_authentication.side_effect = [
+        first_challenge,
+        second_challenge,
+    ]
+    mock_evnex.auth.respond_to_challenge.side_effect = [
+        ChallengeExpiredError("Session lapsed"),
+        make_token_set(),
+    ]
+
+    result = await start_user_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], CREDS)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"mfa_code": "000000"}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "mfa"
+    assert result["errors"] == {"base": "mfa_expired"}
+    assert mock_evnex.auth.start_authentication.call_count == 2
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"mfa_code": "123456"}
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    # The second attempt answered the freshly issued challenge.
+    assert mock_evnex.auth.respond_to_challenge.call_args_list[1].args[0] == (
+        second_challenge
+    )
+
+
+async def test_mfa_expired_restart_unexpected_error_shows_unknown(
+    hass: HomeAssistant, mock_evnex
+) -> None:
+    """An unexpected error while restarting after expiry surfaces as "unknown"."""
+    from evnex.errors import EvnexAuthError
+
+    challenge = mfa_challenge()
+    mock_evnex.auth.start_authentication.side_effect = [
+        challenge,
+        EvnexAuthError("session verification failed"),
+    ]
+    mock_evnex.auth.respond_to_challenge.side_effect = ChallengeExpiredError(
+        "Session lapsed"
+    )
+
+    result = await start_user_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], CREDS)
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"mfa_code": "000000"}
+    )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "mfa"
+    assert result["errors"] == {"base": "unknown"}
 
 
 async def test_user_flow_invalid_credentials(hass: HomeAssistant, mock_evnex) -> None:
-    from evnex.errors import NotAuthorizedException
-
-    mock_evnex.authenticate.side_effect = NotAuthorizedException("Bad creds")
+    mock_evnex.auth.start_authentication.side_effect = InvalidCredentialsError(
+        "Bad creds"
+    )
 
     result = await start_user_flow(hass)
     result = await hass.config_entries.flow.async_configure(result["flow_id"], CREDS)
@@ -90,9 +163,26 @@ async def test_user_flow_invalid_credentials(hass: HomeAssistant, mock_evnex) ->
     assert result["errors"] == {"base": "invalid_credentials"}
 
 
+async def test_user_flow_password_change_required_aborts(
+    hass: HomeAssistant, mock_evnex
+) -> None:
+    mock_evnex.auth.start_authentication.side_effect = PasswordChangeRequiredError(
+        "Password change required"
+    )
+
+    result = await start_user_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], CREDS)
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "password_change_required"
+
+
 async def test_duplicate_account_aborts(hass: HomeAssistant, mock_evnex) -> None:
     MockConfigEntry(
-        domain=DOMAIN, unique_id=USER_ID, data=CREDS, minor_version=3
+        domain=DOMAIN,
+        unique_id=USER_ID,
+        data={"username": CREDS["username"], "tokens": make_token_set().to_dict()},
+        minor_version=4,
     ).add_to_hass(hass)
 
     result = await start_user_flow(hass)
@@ -106,11 +196,16 @@ async def test_reauth_flow_with_mfa(hass: HomeAssistant, mock_evnex) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id=USER_ID,
-        minor_version=3,
-        data={**CREDS, "user_id": USER_ID, "access_token": None},
+        minor_version=4,
+        data={
+            "username": CREDS["username"],
+            "user_id": USER_ID,
+            "tokens": make_token_set(access_token=None).to_dict(),
+        },
     )
     entry.add_to_hass(hass)
-    mock_evnex.authenticate.side_effect = mfa_challenge()
+    challenge = mfa_challenge()
+    mock_evnex.auth.start_authentication.return_value = challenge
 
     entry.async_start_reauth(hass)
     await hass.async_block_till_done()
@@ -128,15 +223,23 @@ async def test_reauth_flow_with_mfa(hass: HomeAssistant, mock_evnex) -> None:
     )
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "reauth_successful"
-    assert entry.data["access_token"] == "access-0"
+    assert entry.data["tokens"] == make_token_set().to_dict()
+    assert "password" not in entry.data
+    assert "id_token" not in entry.data
+    assert "refresh_token" not in entry.data
+    assert "access_token" not in entry.data
 
 
 async def test_reauth_wrong_account_aborts(hass: HomeAssistant, mock_evnex) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         unique_id="different-user",
-        minor_version=3,
-        data={**CREDS, "user_id": "different-user"},
+        minor_version=4,
+        data={
+            "username": CREDS["username"],
+            "user_id": "different-user",
+            "tokens": make_token_set().to_dict(),
+        },
     )
     entry.add_to_hass(hass)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,122 @@
+"""Tests for the evnex integration setup, migration, and coordinator."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from evnex.auth import TokenSet
+from evnex.errors import ReauthenticationRequiredError
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.evnex import async_migrate_entry
+from custom_components.evnex.const import DOMAIN
+from custom_components.evnex.coordinator import EvnexCoordinator, EvnexRuntimeData
+
+from .conftest import USER_ID, make_token_set
+
+
+async def test_migrate_1_3_to_1_4_folds_tokens_and_drops_password(
+    hass: HomeAssistant,
+) -> None:
+    """Flat token fields collapse into a single "tokens" entry, no password."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=USER_ID,
+        version=1,
+        minor_version=3,
+        data={
+            "username": "user@example.com",
+            "password": "hunter2",
+            "user_id": USER_ID,
+            "default_org_id": "org-1",
+            "id_token": "id-0",
+            "refresh_token": "refresh-0",
+            "access_token": "access-0",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry)
+
+    assert entry.minor_version == 4
+    assert (
+        entry.data["tokens"]
+        == TokenSet(
+            id_token="id-0", refresh_token="refresh-0", access_token="access-0"
+        ).to_dict()
+    )
+    assert "password" not in entry.data
+    assert "id_token" not in entry.data
+    assert "refresh_token" not in entry.data
+    assert "access_token" not in entry.data
+    # Untouched fields survive the migration.
+    assert entry.data["username"] == "user@example.com"
+    assert entry.data["user_id"] == USER_ID
+    assert entry.data["default_org_id"] == "org-1"
+
+
+async def test_migrate_full_chain_from_1_1(hass: HomeAssistant) -> None:
+    """A version 1.1 entry migrates all the way to 1.4 in a single pass."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=USER_ID,
+        version=1,
+        minor_version=1,
+        data={
+            "username": "user@example.com",
+            "password": "hunter2",
+            "user_id": USER_ID,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry)
+
+    assert entry.minor_version == 4
+    # No token file exists in the test config dir, so tokens fold to all-None.
+    assert entry.data["tokens"] == TokenSet().to_dict()
+    assert "password" not in entry.data
+    assert "id_token" not in entry.data
+    assert "refresh_token" not in entry.data
+    assert "access_token" not in entry.data
+    assert entry.data["username"] == "user@example.com"
+
+
+async def test_coordinator_reauth_required_raises_config_entry_auth_failed(
+    hass: HomeAssistant,
+) -> None:
+    """A ReauthenticationRequiredError from the client triggers reauth."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=USER_ID,
+        data={"username": "user@example.com", "tokens": make_token_set().to_dict()},
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    client.get_user_detail = AsyncMock(
+        side_effect=ReauthenticationRequiredError("Session expired")
+    )
+
+    coordinator = EvnexCoordinator(hass, client, entry)
+
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coordinator._async_update_data()
+
+
+async def test_runtime_data_wiring(hass: HomeAssistant) -> None:
+    """EvnexRuntimeData exposes the client and coordinator set on the entry."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=USER_ID,
+        data={"username": "user@example.com", "tokens": make_token_set().to_dict()},
+    )
+    entry.add_to_hass(hass)
+
+    client = MagicMock()
+    coordinator = EvnexCoordinator(hass, client, entry)
+    entry.runtime_data = EvnexRuntimeData(client=client, coordinator=coordinator)
+
+    assert entry.runtime_data.client is client
+    assert entry.runtime_data.coordinator is coordinator

--- a/uv.lock
+++ b/uv.lock
@@ -1679,7 +1679,7 @@ wheels = [
 
 [[package]]
 name = "evnex"
-version = "0.6.1"
+version = "0.7.0b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -1689,11 +1689,14 @@ dependencies = [
     { name = "pydantic", version = "2.12.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13.2' and python_full_version < '3.14.2'" },
     { name = "pydantic", version = "2.13.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14.2'" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", version = "2.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.14.2'" },
+    { name = "pyjwt", version = "2.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14.2'" },
+    { name = "qrcode" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/c4/01875121cdb70cf08aa5d445285476688f087e396f4eedc201bb209b27da/evnex-0.6.1.tar.gz", hash = "sha256:a2d9aa0df9026c9b75eb44d94bb2fef7ff157df325cb2c19ed460fc04681259d", size = 87901, upload-time = "2026-07-16T20:45:09.423Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/16/7b0e790f6a358f6ab0d56663573dec22b9eee7ab2490e91dec78410a6a75/evnex-0.7.0b1.tar.gz", hash = "sha256:cadde4ea32a7a5049334f83911f2f1c4bb51f17f719f2e99802a3aabb605a304", size = 116480, upload-time = "2026-07-18T10:01:56.359Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/b1/eafaae081ccca24e6ce459fb7baca8b62cbe1c2f636c9493f5307b1c2b25/evnex-0.6.1-py3-none-any.whl", hash = "sha256:d76d8c0255fa023496c53779159ee139ba658b59a66a714623c8e5c6f3863ea9", size = 20895, upload-time = "2026-07-16T20:45:08Z" },
+    { url = "https://files.pythonhosted.org/packages/90/bb/a8989ac5effd81653db71edb18bf319123b35ede85b9a53b97decd43cce0/evnex-0.7.0b1-py3-none-any.whl", hash = "sha256:757be69da34bdd6edf5ccc652e394fa0ff178d4be474e3b376f0e66068781914", size = 42172, upload-time = "2026-07-18T10:01:55.078Z" },
 ]
 
 [[package]]
@@ -1723,7 +1726,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "evnex", specifier = ">=0.6.1" },
+    { name = "evnex", specifier = ">=0.7.0b1" },
     { name = "homeassistant", specifier = ">=2025.1.0" },
 ]
 
@@ -4835,6 +4838,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "qrcode"
+version = "8.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Beta of ha-evnex 0.9.0, adopting the new `evnex` 0.7 auth lifecycle and modernising the integration. Requires `evnex==0.7.0b1` (now on PyPI).

## Auth adoption
- Build an `EvnexAuth` from the stored `TokenSet` with an async `on_token_update` callback that writes each rotated token set straight back to the config entry. The library refreshes transparently and persists via the callback, so the integration **no longer stores the account password** and no longer drives re-authentication itself.
- Migration **1.3 → 1.4**: fold the flat `id_token`/`refresh_token`/`access_token` fields into a single `"tokens"` (`TokenSet`) entry and drop the stored password. Reauth collects the password interactively when needed.
- Coordinator maps `EvnexAuthError` (incl. `ReauthenticationRequiredError`) → `ConfigEntryAuthFailed` to trigger the reauth flow; the manual retry/MFA dance is gone.

## Config flow (rewritten on the typed API)
- `start_authentication` / `respond_to_challenge` with the typed error taxonomy: MFA challenge retry (same challenge on a wrong code), automatic restart on challenge expiry, `password_change_required` abort, and `wrong_account` abort on reauth.
- Reauth updates the token set and strips any legacy password/token keys from entry data.

## Modernisation
- `ConfigFlowResult`, a real `EvnexCoordinator(DataUpdateCoordinator[...])`, and `entry.runtime_data` (typed `EvnexConfigEntry`) replacing `hass.data[DOMAIN][...]` across all platforms; `DATA_CLIENT`/`DATA_COORDINATOR` removed.
- Removed the vestigial `async_setup`; `actions/checkout` bumped to v6 and the stale pip-cache step dropped from the hassfest/HACS job.
- `manifest` requires `evnex==0.7.0b1`, version `0.9.0b1`.

## Tests
Rewritten on real `TokenSet`/`AuthChallenge`/error classes from evnex 0.7.0b1: user happy path, MFA success, wrong-code recovery (same challenge reused), challenge-expiry restart (fresh challenge) incl. the unexpected-error-during-restart path, invalid credentials, password-change abort, duplicate account, reauth (asserts tokens updated and password/legacy keys stripped), wrong-account abort, migration **1.1 → 1.4** full-chain and **1.3 → 1.4**, and coordinator `ReauthenticationRequiredError → ConfigEntryAuthFailed`. 14 passing; ruff + format clean.

## Known / deferred
- Two pre-existing mypy errors (`switch.py:208`, `sensor.py:316`) are unrelated to this change and left for a focused follow-up.
- Container / live end-to-end validation against a real charger is the next step before promoting past beta.