### PR TITLE
Remove obsolete Pydantic v2 install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@ Available as an integration in HACS.
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=hardbyte&repository=ha-evnex&category=integration)
 
 
-Since version `0.6.0` this integration requires Pydantic >2.0, some versions of Home Assistant may not have this version 
-available, you may need to install it manually e.g. with `pip install -U pydantic`.
-
-
 ## Sensors
 
 Each charger device exposes:


### PR DESCRIPTION
The README warned that HACS/HA might not ship Pydantic >2.0 and users may need to `pip install -U pydantic` manually. That dates from when Home Assistant was still on Pydantic v1; current HA ships Pydantic v2 (and the evnex dependency pulls it in regardless), so the note is stale and misleading. Remove it.