### PR TITLE
Stop the stop-session button logging a spurious "pressed" event

### DIFF
--- a/custom_components/evnex/button.py
+++ b/custom_components/evnex/button.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from collections.abc import Awaitable, Callable
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .coordinator import EvnexConfigEntry
@@ -33,18 +34,14 @@ def _is_charger_session_ready(
 
 @dataclass(frozen=True, kw_only=True)
 class EvnexButtonSensorEntityDescription(ButtonEntityDescription):
-    """Describes Mammotion button sensor entity."""
+    """Describes an Evnex button entity."""
 
     press_fn: Callable[[Evnex, str, str], Awaitable[None]]
-    available: Callable[[EvnexCoordinator, str, str], bool]
 
 
 EVNEX_BUTTONS: tuple[EvnexButtonSensorEntityDescription, ...] = (
     EvnexButtonSensorEntityDescription(
         key="charger_stop_session",
-        available=lambda coordinator, charger_id, connector_id: (
-            _is_charger_session_ready(coordinator, charger_id, connector_id)
-        ),
         press_fn=lambda evnex_api, charge_point_id, org_id: evnex_api.stop_charge_point(
             charge_point_id=charge_point_id, org_id=org_id
         ),
@@ -118,10 +115,17 @@ class EvnexChargerButtonEntity(EvnexChargerEntity, ButtonEntity):
         self._attr_translation_key = entity_description.key
 
     async def async_press(self) -> None:
-        """Handle the button press."""
+        """Stop the active charging session.
+
+        Availability is deliberately left to the coordinator rather than gated
+        on the session state: a momentary button that toggled availability logs
+        a spurious "pressed" event every time it reappeared (the unavailable ->
+        unknown state edge). The session-ready check is enforced here instead,
+        raising a clear error when there is nothing to stop.
+        """
+        if not _is_charger_session_ready(self.coordinator, self.charger_id, "1"):
+            raise HomeAssistantError(
+                "Can't stop charging: the charge point has no active session"
+            )
         await self.entity_description.press_fn(self.evnex, self.charger_id, self.org_id)
         await self.coordinator.async_refresh()
-
-    @property
-    def available(self) -> bool:
-        return self.entity_description.available(self.coordinator, self.charger_id, "1")

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,51 @@
+"""Tests for the Evnex stop-session button.
+
+The button intentionally stays available (its availability follows coordinator
+health) so it does not log a spurious "pressed" event each time it would
+otherwise reappear; the session-ready guard lives in async_press instead.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.evnex.button import EVNEX_BUTTONS, EvnexChargerButtonEntity
+
+
+def _make_entity(*, ready: bool) -> EvnexChargerButtonEntity:
+    # Bypass the heavy EvnexChargerEntity.__init__; async_press only needs
+    # these attributes.
+    entity = EvnexChargerButtonEntity.__new__(EvnexChargerButtonEntity)
+    entity.evnex = MagicMock()
+    entity.evnex.stop_charge_point = AsyncMock()
+    entity.charger_id = "cp-1"
+    entity.org_id = "org-1"
+    entity.entity_description = EVNEX_BUTTONS[0]
+
+    coordinator = MagicMock()
+    coordinator.async_refresh = AsyncMock()
+    detail = MagicMock()
+    detail.networkStatus = "ONLINE" if ready else "OFFLINE"
+    coordinator.data.charge_point_details = {"cp-1": detail}
+    connector = MagicMock()
+    connector.ocppStatus = "CHARGING" if ready else "AVAILABLE"
+    coordinator.data.connector_brief = {("cp-1", "1"): connector}
+    entity.coordinator = coordinator
+    return entity
+
+
+async def test_stop_button_raises_when_no_active_session() -> None:
+    entity = _make_entity(ready=False)
+    with pytest.raises(HomeAssistantError):
+        await entity.async_press()
+    entity.evnex.stop_charge_point.assert_not_called()
+
+
+async def test_stop_button_stops_when_session_active() -> None:
+    entity = _make_entity(ready=True)
+    await entity.async_press()
+    entity.evnex.stop_charge_point.assert_awaited_once_with(
+        charge_point_id="cp-1", org_id="org-1"
+    )
+    entity.coordinator.async_refresh.assert_awaited_once()


### PR DESCRIPTION
Surfaced during live beta testing: the device activity feed showed **"Stop charging session: Pressed"** the instant charging began, even though nobody pressed it and charging continued.

**Root cause** (confirmed against the HA `logbook`/`button` source): the button gated its `available` on the connector being session-ready, so it flipped `unavailable → available` when charging started. For a momentary `ButtonEntity` (state is the last-press timestamp, `None` until pressed), that edge is a genuine `unavailable → unknown` `state_changed`, which the logbook keeps and the **frontend renders as "Pressed"** for the button domain. The backend event carries `state: "unknown"` — no press occurred and no command ran.

**Fix:** stop gating availability (let it follow coordinator health, the idiomatic pattern for a momentary button) and move the session-ready check into `async_press`, raising `HomeAssistantError` when there's no active session. This removes the churn — and the false "Pressed" — while preserving the "can't stop when nothing's charging" behaviour (now a clear error toast instead of a greyed button).

Tests added for both branches of `async_press`. Alternatives considered and rejected (per source review): recorder/EntityCategory tweaks and suppressing coordinator writes don't stop the state edge; per-entity `logbook.exclude` also hides real presses and is user config, not an integration fix.