### PR TITLE
Add connector status icons

### DIFF
--- a/custom_components/evnex/icons.json
+++ b/custom_components/evnex/icons.json
@@ -67,6 +67,21 @@
       },
       "connector_power": {
         "default": "mdi:flash-triangle"
+      },
+      "connector_status": {
+        "default": "mdi:ev-station",
+        "state": {
+          "available": "mdi:power-plug",
+          "preparing": "mdi:timer-sand",
+          "charging": "mdi:battery-charging",
+          "suspended_evse": "mdi:pause-circle-outline",
+          "suspended_ev": "mdi:car-electric-outline",
+          "finishing": "mdi:flag-checkered",
+          "reserved": "mdi:calendar-clock",
+          "unavailable": "mdi:power-plug-off",
+          "faulted": "mdi:alert-circle",
+          "offline": "mdi:wifi-off"
+        }
       }
     }
   }


### PR DESCRIPTION
The connector-status sensor had no icon mapping, so HA showed a generic "?" for every state. Add state icons (charging, available, suspended_ev, faulted, offline, etc.) so the connector status renders sensibly on device pages and dashboards. Surfaced during beta dashboard testing.