### PR TITLE
Add a per-connector energy meter sensor for the Energy dashboard

### DIFF
--- a/custom_components/evnex/icons.json
+++ b/custom_components/evnex/icons.json
@@ -82,6 +82,9 @@
           "faulted": "mdi:alert-circle",
           "offline": "mdi:wifi-off"
         }
+      },
+      "connector_energy_meter": {
+        "default": "mdi:counter"
       }
     }
   }

--- a/custom_components/evnex/sensor.py
+++ b/custom_components/evnex/sensor.py
@@ -577,14 +577,14 @@ class EvnexChargePortConnectorEnergyMeterSensor(
         )
 
     @property
-    def native_value(self):
+    def native_value(self) -> float | None:
         """Return the lifetime imported energy in kWh."""
-        self.connector_brief = self.coordinator.data.connector_brief.get(
+        connector = self.coordinator.data.connector_brief.get(
             (self.charger_id, self.connector_id)
         )
-        if not self.connector_brief or not self.connector_brief.meter:
+        if not connector or not connector.meter:
             return None
-        return self.connector_brief.meter.raw_register / 1000
+        return connector.meter.raw_register / 1000
 
 
 class EvnexChargePortConnectorSupplyPowerSensor(

--- a/custom_components/evnex/sensor.py
+++ b/custom_components/evnex/sensor.py
@@ -547,6 +547,46 @@ class EvnexChargePortConnectorPowerSensor(
         return self.connector_brief.meter.power / 1000
 
 
+class EvnexChargePortConnectorEnergyMeterSensor(
+    EvnexChargePointConnectorEntity, SensorEntity
+):
+    """Lifetime energy imported through a connector."""
+
+    entity_description = SensorEntityDescription(
+        key="connector_energy_meter",
+        device_class=SensorDeviceClass.ENERGY,
+        native_unit_of_measurement=UnitOfEnergy.KILO_WATT_HOUR,
+        state_class=SensorStateClass.TOTAL_INCREASING,
+        suggested_display_precision=2,
+    )
+
+    def __init__(
+        self,
+        coordinator: EvnexCoordinator,
+        charger_id: str,
+        org_id: str,
+        connector_id: str = "1",
+    ) -> None:
+        """Initialize the connector energy meter sensor."""
+        super().__init__(
+            coordinator=coordinator,
+            charger_id=charger_id,
+            org_id=org_id,
+            connector_id=connector_id,
+            key=self.entity_description.key,
+        )
+
+    @property
+    def native_value(self):
+        """Return the lifetime imported energy in kWh."""
+        self.connector_brief = self.coordinator.data.connector_brief.get(
+            (self.charger_id, self.connector_id)
+        )
+        if not self.connector_brief or not self.connector_brief.meter:
+            return None
+        return self.connector_brief.meter.raw_register / 1000
+
+
 class EvnexChargePortConnectorSupplyPowerSensor(
     EvnexChargePointConnectorEntity, SensorEntity
 ):
@@ -800,6 +840,11 @@ async def async_setup_entry(
 
                 entities.append(
                     EvnexChargePortConnectorPowerSensor(
+                        coordinator, charger_id, org_id_for_charger, connector_id
+                    )
+                )
+                entities.append(
+                    EvnexChargePortConnectorEnergyMeterSensor(
                         coordinator, charger_id, org_id_for_charger, connector_id
                     )
                 )

--- a/custom_components/evnex/strings.json
+++ b/custom_components/evnex/strings.json
@@ -140,6 +140,9 @@
       "connector_power": {
         "name": "Metered power"
       },
+      "connector_energy_meter": {
+        "name": "Energy meter"
+      },
       "connector_voltage_l1": {
         "name": "Voltage L1"
       },

--- a/custom_components/evnex/translations/en.json
+++ b/custom_components/evnex/translations/en.json
@@ -77,6 +77,9 @@
             "connector_power": {
                 "name": "Metered power"
             },
+            "connector_energy_meter": {
+                "name": "Energy meter"
+            },
             "connector_status": {
                 "name": "Connector status",
                 "state": {

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,36 @@
+"""Tests for Evnex sensors."""
+
+from unittest.mock import MagicMock
+
+from custom_components.evnex.sensor import EvnexChargePortConnectorEnergyMeterSensor
+
+
+def _make_energy_meter_sensor(*, raw_register: float | None):
+    """Construct a connector energy sensor with mocked coordinator data."""
+    sensor = EvnexChargePortConnectorEnergyMeterSensor.__new__(
+        EvnexChargePortConnectorEnergyMeterSensor
+    )
+    sensor.charger_id = "cp-1"
+    sensor.connector_id = "1"
+
+    coordinator = MagicMock()
+    connector = MagicMock()
+    if raw_register is None:
+        connector.meter = None
+    else:
+        connector.meter.raw_register = raw_register
+    coordinator.data.connector_brief = {("cp-1", "1"): connector}
+    sensor.coordinator = coordinator
+    return sensor
+
+
+def test_connector_energy_meter_converts_wh_to_kwh() -> None:
+    sensor = _make_energy_meter_sensor(raw_register=12345.0)
+
+    assert sensor.native_value == 12.345
+
+
+def test_connector_energy_meter_is_unavailable_without_meter() -> None:
+    sensor = _make_energy_meter_sensor(raw_register=None)
+
+    assert sensor.native_value is None


### PR DESCRIPTION
Adds a per-connector **cumulative energy sensor** so an Evnex charger can be added to Home Assistant's **Energy dashboard** (Settings → Energy → Individual devices) — the top ask for an EV charger.

- Reads the connector's OCPP lifetime import register (`connector.meter.raw_register`, watt-hours) — a monotonic value the coordinator **already fetches**, so no extra API call.
- Exposed as `device_class: energy`, `state_class: total_increasing`, unit **kWh** (`raw_register / 1000`), `suggested_display_precision: 2`.
- Returns `None` (unavailable) when the connector or its meter is absent, so it never publishes a bogus `0` that would corrupt Energy statistics.
- Adds icon (`mdi:counter`) and the "Energy meter" name to `strings.json` + `en.json`; registered per-connector in `sensor.py`.

Tests cover the kWh conversion and the meter-absent → unavailable path.

Implemented by a Codex CLI agent in a worktree, then reviewed and refined (native_value now reads the connector into a local rather than mutating `self.connector_brief`; rebased onto the connector-icons change). 19 tests pass; ruff clean. Targets 0.9.