### PR TITLE
Release 0.9.0b2 (pin evnex==0.7.0b2)

### DIFF
--- a/custom_components/evnex/const.py
+++ b/custom_components/evnex/const.py
@@ -6,7 +6,7 @@ from homeassistant.const import Platform
 NAME = "evnex"
 DOMAIN = "evnex"
 DOMAIN_DATA = f"{DOMAIN}_data"
-VERSION = "0.9.0b1"
+VERSION = "0.9.0b2"
 ATTRIBUTION = "Data provided by https://evnex.io"
 ISSUE_URL = "https://github.com/hardbyte/ha-evnex/issues"
 

--- a/custom_components/evnex/manifest.json
+++ b/custom_components/evnex/manifest.json
@@ -13,7 +13,7 @@
     "evnex"
   ],
   "requirements": [
-    "evnex==0.7.0b1"
+    "evnex==0.7.0b2"
   ],
-  "version": "0.9.0b1"
+  "version": "0.9.0b2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 requires-python = ">=3.13"
 dependencies = [
     "homeassistant >= 2025.1.0",
-    "evnex >= 0.7.0b1",
+    "evnex >= 0.7.0b2",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -1679,7 +1679,7 @@ wheels = [
 
 [[package]]
 name = "evnex"
-version = "0.7.0b1"
+version = "0.7.0b2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boto3" },
@@ -1694,9 +1694,9 @@ dependencies = [
     { name = "qrcode" },
     { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b2/16/7b0e790f6a358f6ab0d56663573dec22b9eee7ab2490e91dec78410a6a75/evnex-0.7.0b1.tar.gz", hash = "sha256:cadde4ea32a7a5049334f83911f2f1c4bb51f17f719f2e99802a3aabb605a304", size = 116480, upload-time = "2026-07-18T10:01:56.359Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/6f/0e8cfa257bbb73f274bb6e65e7192487e1f5f9a0cbbd24246c0f18533e89/evnex-0.7.0b2.tar.gz", hash = "sha256:b6b4743368f89ded9091f5544e9b7e07b7ba997ae738dc02404cea376da2c0d4", size = 117151, upload-time = "2026-07-19T10:15:36.706Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/90/bb/a8989ac5effd81653db71edb18bf319123b35ede85b9a53b97decd43cce0/evnex-0.7.0b1-py3-none-any.whl", hash = "sha256:757be69da34bdd6edf5ccc652e394fa0ff178d4be474e3b376f0e66068781914", size = 42172, upload-time = "2026-07-18T10:01:55.078Z" },
+    { url = "https://files.pythonhosted.org/packages/71/83/dfd15f7a3cea45bdc49fff321e554016aec8991615839d6bfbbca11c5848/evnex-0.7.0b2-py3-none-any.whl", hash = "sha256:2b8c1c4173f31fc99ba772363ef11cf4f99c7d845864d5e4771b598e8629eae5", size = 42418, upload-time = "2026-07-19T10:15:35.125Z" },
 ]
 
 [[package]]
@@ -1726,7 +1726,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "evnex", specifier = ">=0.7.0b1" },
+    { name = "evnex", specifier = ">=0.7.0b2" },
     { name = "homeassistant", specifier = ">=2025.1.0" },
 ]
 


### PR DESCRIPTION
Second beta of 0.9.0, bundling everything merged since 0.9.0b1:

- Stop-session button no longer logs a spurious "Pressed" when charging starts (#97)
- Connector status icons (#98)
- **Energy-dashboard sensor** — per-connector `total_increasing` kWh meter for the HA Energy dashboard (#99)
- Updated README screenshot (#100)

Pins `evnex==0.7.0b2` (fail-fast charge-now command timeout, configured-org honouring, `--json` stdout purity). Version `0.9.0b2`.