### PR TITLE
Let icons.json drive the connector status icon

### DIFF
--- a/custom_components/evnex/sensor.py
+++ b/custom_components/evnex/sensor.py
@@ -397,32 +397,11 @@ class EvnexChargePortConnectorStatusSensor(
             return str.lower(self.connector_brief.ocppStatus)
         return None
 
-    @property
-    def icon(self):
-        """Return the icon of the sensor."""
-        icon = "mdi:help-circle"
-        status = self.native_value
-        if status == "AVAILABLE":
-            icon = "mdi:power-plug-off"
-        elif status == "PREPARING":
-            return "mdi:power-plug-outline"
-        elif (
-            status == "OCCUPIED"
-            or status == "SUSPENDED_EVSE"
-            or status == "SUSPENDED_EV"
-        ):
-            icon = "mdi:power-plug"
-        elif status == "CHARGING":
-            icon = "mdi:battery-positive"
-        elif status == "FINISHING":
-            icon = "mdi:power-plug-off-outline"
-        elif status == "RESERVED":
-            icon = "mdi:timer-sand"
-        elif status == "UNAVAILABLE":
-            icon = "mdi:lan-disconnect"
-        elif status == "FAULTED":
-            icon = "mdi:alert-circle"
-        return icon
+    # Icons come from icons.json (keyed by the lowercase state). A previous
+    # `icon` property compared against uppercase statuses that never matched
+    # the lowercase native_value, so it always fell back to mdi:help-circle
+    # and, because an entity-supplied icon overrides icons.json, hid the state
+    # icons entirely.
 
 
 class EvnexChargePortConnectorVoltageSensor(


### PR DESCRIPTION
Follow-up to #98, raised by post-merge Codex review. The connector-status sensor's `icon` property compared against **uppercase** OCPP statuses while `native_value` returns the **lowercase** status, so it never matched and always returned `mdi:help-circle`. An entity-supplied icon overrides `icons.json`, so the state icons added in #98 were never used and the generic "?" persisted on device pages. Removing the property lets the `icons.json` state map (lowercase keys, matching the state) apply. 19 tests pass; ruff clean.