### PR TITLE
Add connector plugged-in and charging binary sensors

### DIFF
--- a/custom_components/evnex/binary_sensor.py
+++ b/custom_components/evnex/binary_sensor.py
@@ -1,0 +1,148 @@
+"""Binary sensor platform for evnex."""
+
+import logging
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+    BinarySensorEntityDescription,
+)
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .coordinator import EvnexConfigEntry, EvnexCoordinator
+from .entity import EvnexChargePointConnectorEntity
+
+_LOGGER = logging.getLogger(__name__)
+
+PLUGGED_IN_STATES = {
+    "preparing",
+    "charging",
+    "suspended_ev",
+    "suspended_evse",
+    "finishing",
+}
+
+
+class EvnexConnectorPluggedInBinarySensor(
+    EvnexChargePointConnectorEntity, BinarySensorEntity
+):
+    """Report whether a vehicle is plugged into a connector."""
+
+    entity_description = BinarySensorEntityDescription(
+        key="connector_plugged_in",
+        device_class=BinarySensorDeviceClass.PLUG,
+    )
+
+    def __init__(
+        self,
+        coordinator: EvnexCoordinator,
+        charger_id: str,
+        org_id: str,
+        connector_id: str,
+    ) -> None:
+        super().__init__(
+            coordinator,
+            charger_id,
+            org_id,
+            connector_id,
+            key=self.entity_description.key,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether a vehicle is plugged into the connector."""
+        connector = self.coordinator.data.connector_brief.get(
+            (self.charger_id, self.connector_id)
+        )
+        if (
+            connector is None
+            or (ocpp_status := getattr(connector, "ocppStatus", None)) is None
+        ):
+            return None
+        return ocpp_status.lower() in PLUGGED_IN_STATES
+
+
+class EvnexConnectorChargingBinarySensor(
+    EvnexChargePointConnectorEntity, BinarySensorEntity
+):
+    """Report whether a connector is charging a vehicle."""
+
+    entity_description = BinarySensorEntityDescription(
+        key="connector_charging",
+        device_class=BinarySensorDeviceClass.BATTERY_CHARGING,
+    )
+
+    def __init__(
+        self,
+        coordinator: EvnexCoordinator,
+        charger_id: str,
+        org_id: str,
+        connector_id: str,
+    ) -> None:
+        super().__init__(
+            coordinator,
+            charger_id,
+            org_id,
+            connector_id,
+            key=self.entity_description.key,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the connector is charging a vehicle."""
+        connector = self.coordinator.data.connector_brief.get(
+            (self.charger_id, self.connector_id)
+        )
+        if (
+            connector is None
+            or (ocpp_status := getattr(connector, "ocppStatus", None)) is None
+        ):
+            return None
+        return ocpp_status.lower() == "charging"
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: EvnexConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up the binary sensor platform."""
+    coordinator = config_entry.runtime_data.coordinator
+
+    entities: list[BinarySensorEntity] = []
+    if not coordinator.data:
+        _LOGGER.warning("Coordinator data not available for binary sensor setup")
+        return
+
+    charge_point_to_org_map = coordinator.data.charge_point_to_org_map
+    for charger_id in coordinator.data.charge_point_brief:
+        org_id_for_charger = charge_point_to_org_map.get(charger_id)
+        if org_id_for_charger is None:
+            _LOGGER.warning(
+                f"Charger {charger_id} does not have an associated organization ID."
+            )
+            continue
+
+        charge_point_detail_v3 = coordinator.data.charge_point_details.get(charger_id)
+        if charge_point_detail_v3 and charge_point_detail_v3.connectors:
+            for connector_detail_v3 in charge_point_detail_v3.connectors:
+                connector_id = connector_detail_v3.connectorId
+                entities.extend(
+                    (
+                        EvnexConnectorPluggedInBinarySensor(
+                            coordinator,
+                            charger_id,
+                            org_id_for_charger,
+                            connector_id,
+                        ),
+                        EvnexConnectorChargingBinarySensor(
+                            coordinator,
+                            charger_id,
+                            org_id_for_charger,
+                            connector_id,
+                        ),
+                    )
+                )
+
+    async_add_entities(entities)

--- a/custom_components/evnex/const.py
+++ b/custom_components/evnex/const.py
@@ -11,7 +11,13 @@ ATTRIBUTION = "Data provided by https://evnex.io"
 ISSUE_URL = "https://github.com/hardbyte/ha-evnex/issues"
 
 # Platforms
-PLATFORMS = [Platform.SENSOR, Platform.SWITCH, Platform.NUMBER, Platform.BUTTON]
+PLATFORMS = [
+    Platform.SENSOR,
+    Platform.BINARY_SENSOR,
+    Platform.SWITCH,
+    Platform.NUMBER,
+    Platform.BUTTON,
+]
 
 # Configuration and options
 CONF_USERNAME = "username"

--- a/custom_components/evnex/strings.json
+++ b/custom_components/evnex/strings.json
@@ -51,6 +51,14 @@
     }
   },
   "entity": {
+    "binary_sensor": {
+      "connector_plugged_in": {
+        "name": "Plugged in"
+      },
+      "connector_charging": {
+        "name": "Charging"
+      }
+    },
     "button": {
       "charger_stop_session": {
         "name": "Stop charging session"

--- a/custom_components/evnex/translations/en.json
+++ b/custom_components/evnex/translations/en.json
@@ -38,6 +38,14 @@
         }
     },
     "entity": {
+        "binary_sensor": {
+            "connector_charging": {
+                "name": "Charging"
+            },
+            "connector_plugged_in": {
+                "name": "Plugged in"
+            }
+        },
         "button": {
             "charger_stop_session": {
                 "name": "Stop charging session"

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,57 @@
+"""Tests for Evnex binary sensors."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from custom_components.evnex.binary_sensor import (
+    EvnexConnectorChargingBinarySensor,
+    EvnexConnectorPluggedInBinarySensor,
+)
+
+
+def _make_sensors(
+    ocpp_status: str | None,
+) -> tuple[EvnexConnectorPluggedInBinarySensor, EvnexConnectorChargingBinarySensor]:
+    """Construct connector binary sensors with mocked coordinator data."""
+    plugged_in = EvnexConnectorPluggedInBinarySensor.__new__(
+        EvnexConnectorPluggedInBinarySensor
+    )
+    charging = EvnexConnectorChargingBinarySensor.__new__(
+        EvnexConnectorChargingBinarySensor
+    )
+
+    coordinator = MagicMock()
+    connector_brief = {}
+    if ocpp_status is not None:
+        connector = MagicMock()
+        connector.ocppStatus = ocpp_status
+        connector_brief[("cp-1", "1")] = connector
+    coordinator.data.connector_brief = connector_brief
+
+    for sensor in (plugged_in, charging):
+        sensor.charger_id = "cp-1"
+        sensor.connector_id = "1"
+        sensor.coordinator = coordinator
+
+    return plugged_in, charging
+
+
+@pytest.mark.parametrize(
+    ("ocpp_status", "plugged_in_state", "charging_state"),
+    [
+        ("Charging", True, True),
+        ("SUSPENDED_EV", True, False),
+        ("available", False, False),
+        (None, None, None),
+    ],
+)
+def test_connector_binary_sensor_states(
+    ocpp_status: str | None,
+    plugged_in_state: bool | None,
+    charging_state: bool | None,
+) -> None:
+    plugged_in, charging = _make_sensors(ocpp_status)
+
+    assert plugged_in.is_on is plugged_in_state
+    assert charging.is_on is charging_state


### PR DESCRIPTION
Adds a `binary_sensor` platform with two per-connector sensors derived from the connector's OCPP status — so automations don't have to string-match the `connector_status` enum:

- **`binary_sensor.…_plugged_in`** (`device_class: plug`) — on when the status is one of `preparing`, `charging`, `suspended_ev`, `suspended_evse`, `finishing`; off for `available`/`offline`/etc.; unavailable when the connector/status is missing.
- **`binary_sensor.…_charging`** (`device_class: battery_charging`) — on only when `charging`.

Reads the connector fresh from coordinator data (no `self` mutation); `device_class` supplies the icons. `Platform.BINARY_SENSOR` added to `PLATFORMS`; names in `strings.json` + `en.json`. Tests cover charging/suspended/available/missing (including mixed-case status). 23 tests pass; ruff clean.

Implemented via the Codex-in-worktree flow, then reviewed. Targets 0.9.